### PR TITLE
Update priv_dir determination

### DIFF
--- a/src/gen_script.erl
+++ b/src/gen_script.erl
@@ -110,18 +110,12 @@ code_change(_OldVsn, State, _Extra) ->
 
 -spec boot_script(source_file()) -> command().
 boot_script({ruby, File}) ->
-    RubyDir = filename:join([app_root(), "priv", "ruby"]),
+    RubyDir = filename:join([code:priv_dir(gen_script), "ruby"]),
     BertDir = filename:join([RubyDir, "bert", "lib"]),
     GSDir = filename:join(RubyDir, "gen_script"),
     lists:flatten(io_lib:format("ruby -I ~s -I ~s -r gen_script ~s", [BertDir, GSDir, File]));
 boot_script(ScriptFile) ->
     ScriptFile.
-
--spec app_root() -> filepath().
-app_root() ->
-    Dir = filename:dirname(code:where_is_file("gen_script.app")),
-    filename:join(Dir, "..").
-
 
 maybe_reply(_, noreply) -> ok;
 maybe_reply(undefined, _) -> ok;


### PR DESCRIPTION
The use of `code:where_is_file("gen_script.app")` to determine the location of priv_dir is flawed when dealing with erlang archive files (.ez).  This strategy doesn't work for archive files because the .app is inside the archive and the priv dir is outside the archive.  Erlang's `code:priv_dir/1` seems to make this determination strategy unnecessary.