### PR TITLE
Remove 14x OTP releases and add newer ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: erlang
 otp_release:
+   - 19.2
+   - 18.3
+   - 17.5
    - R16B
    - R15B03
    - R15B02
    - R15B01
    - R15B
-   - R14B04
-   - R14B03
-   - R14B02


### PR DESCRIPTION
The 14 series of OTP releases is really old.  This PR removes it and adds more current versions.